### PR TITLE
Send loot on data pack sync rather than on player join

### DIFF
--- a/src/main/java/fzzyhmstrs/emi_loot/client/ClientLootTables.java
+++ b/src/main/java/fzzyhmstrs/emi_loot/client/ClientLootTables.java
@@ -1,6 +1,7 @@
 package fzzyhmstrs.emi_loot.client;
 
 import fzzyhmstrs.emi_loot.EMILoot;
+import fzzyhmstrs.emi_loot.parser.LootTableParser;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 
@@ -23,6 +24,9 @@ public class ClientLootTables {
     public void registerClient(){
         
         ClientPlayConnectionEvents.DISCONNECT.register((handler,client) -> loots.clear());
+
+        ClientPlayNetworking.registerGlobalReceiver(LootTableParser.CLEAR_LOOTS, (minecraftClient, playNetworkHandler, buf, sender) ->
+                loots.clear());
         
         ClientPlayNetworking.registerGlobalReceiver(CHEST_SENDER,(minecraftClient, playNetworkHandler, buf, sender)-> {
             LootReceiver table = ClientChestLootTable.INSTANCE.fromBuf(buf);


### PR DESCRIPTION
This fixes an issue where changing loot tables on the server (such as by enabling/disabling/modifying a data pack) wouldn't be reflected on the client until rejoining.