### PR TITLE
Fix EmiRecipe#getInputs for BlockLootRecipe and MobLootRecipe

### DIFF
--- a/src/main/java/fzzyhmstrs/emi_loot/emi/BlockLootRecipe.java
+++ b/src/main/java/fzzyhmstrs/emi_loot/emi/BlockLootRecipe.java
@@ -78,7 +78,7 @@ public class BlockLootRecipe implements EmiRecipe {
 
     @Override
     public List<EmiIngredient> getInputs() {
-        return new LinkedList<>();
+        return List.of(inputStack);
     }
 
     @Override

--- a/src/main/java/fzzyhmstrs/emi_loot/emi/MobLootRecipe.java
+++ b/src/main/java/fzzyhmstrs/emi_loot/emi/MobLootRecipe.java
@@ -127,7 +127,13 @@ public class MobLootRecipe implements EmiRecipe {
 
     @Override
     public List<EmiIngredient> getInputs() {
-        return new LinkedList<>();
+        if (inputStack instanceof EntityEmiStack entityStack
+                && entityStack.getKey() instanceof Entity entity
+                && entity.getPickBlockStack() != null) {
+            return List.of(EmiStack.of(entity.getPickBlockStack()));
+        } else {
+            return new LinkedList<>();
+        }
     }
 
     @Override


### PR DESCRIPTION
Returns the block dropping loot and the spawn egg of the entity (if it exists), respectively

Partially fixes #48