### PR TITLE
Fix NeoForge accesstransformer.cfg + various buildscript updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v2
-
       - name: Setup JDK 21
         uses: actions/setup-java@v4
         with:
@@ -32,8 +29,8 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle
 
-      - name: Make Gradle wrapper executable
-        run: chmod +x ./gradlew
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Build Fabric
         run: ./gradlew :fabric:build
@@ -48,4 +45,3 @@ jobs:
           path: |
             fabric/build/libs/
             neoforge/build/libs/
- 

--- a/README.md
+++ b/README.md
@@ -8,17 +8,18 @@ Emi Loot is a plugin for [EMI](https://github.com/emilyploszaj/emi) that display
 Credit for loot condition icon art goes to [lxly9](https://github.com/lxly9). Thank you!!
 
 ## Known Compatible Loot or Content Mods:
-* [Lootify](https://modrinth.com/mod/lootify)
-* [Loot Config](https://www.curseforge.com/minecraft/mc-mods/loot-config)
-* [Dark Loot](https://www.curseforge.com/minecraft/mc-mods/darkloot-better-mob-loot)
 * [Amethyst Imbuement](https://modrinth.com/mod/amethyst-imbuement)
-* [Immersive Weathering](https://modrinth.com/mod/immersive-weathering)
 * [Botania](https://modrinth.com/mod/botania)
+* [Dark Loot](https://www.curseforge.com/minecraft/mc-mods/darkloot-better-mob-loot)
+* [Immersive Weathering](https://modrinth.com/mod/immersive-weathering)
+* [Loot Config](https://www.curseforge.com/minecraft/mc-mods/loot-config)
+* [Lootify](https://modrinth.com/mod/lootify)
 
 ## Known INCOMPATIBLE Mods
-* [LootJS](https://modrinth.com/mod/lootjs): Affects drops on generation, doesn't modify loot tables themselves.
-* [Better Nether](https://www.curseforge.com/minecraft/mc-mods/betternether): Hardcoded drops
+* (Neo)Forge / [Porting Lib](https://github.com/Fabricators-of-Create/Porting-Lib) Global Loot Modifiers: Affects drops on generation, doesn't modify loot tables themselves.
 * [Better End](https://www.curseforge.com/minecraft/mc-mods/betterend): Hardcoded drops
+* [Better Nether](https://www.curseforge.com/minecraft/mc-mods/betternether): Hardcoded drops
+* [LootJS](https://modrinth.com/mod/lootjs): Affects drops on generation, doesn't modify loot tables themselves.
 * [Paradise Lost](https://www.curseforge.com/minecraft/mc-mods/paradise-lost): Hardcoded drops
 
 ## TODO LIST

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     modRuntimeOnly "me.fzzyhmstrs:fzzy_config:${rootProject.fzzy_config_version}"
     modRuntimeOnly "maven.modrinth:symbols-n-stuff:${rootProject.sns_version}"
 
-    modRuntimeOnly "maven.modrinth:fabric-language-kotlin:${rootProject.flk_version}"
+    modRuntimeOnly "net.fabricmc:fabric-language-kotlin:${rootProject.flk_version}"
 
     common(project(path: ":xplat", configuration: "namedElements")) { transitive false }
     shadowCommon(project(path: ":xplat", configuration: "transformProductionFabric")) { transitive false }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,9 +6,9 @@ minecraft_version=1.21.1
 yarn_mappings=1.21.1+build.3
 neoforge_yarn_patch=1.21+build.4
 enabled_platforms=fabric,neoforge
-fabric_api_version=0.104.0+1.21.1
-fabric_loader_version=0.16.5
-neoforge_version=21.1.50
+fabric_api_version=0.110.0+1.21.1
+fabric_loader_version=0.16.9
+neoforge_version=21.1.89
 
 # Mod Properties
 mod_version=0.7.4+1.21
@@ -16,10 +16,10 @@ maven_group=fzzyhmstrs
 archives_base_name=emi_loot
 
 # Dependencies
-emi_version=1.1.13+1.21.1
-fzzy_config_version=0.4.3+1.21
-sns_version=0.1.1+1.21
+emi_version=1.1.18+1.21.1
+fzzy_config_version=0.5.9+1.21
+sns_version=0.1.2+1.21
 
 # Runtime Dependencies
-flk_version=1.12.1+kotlin.2.0.20
+flk_version=1.13.0+kotlin.2.1.0
 kff_version=5.5.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -35,6 +35,12 @@ repositories {
             includeGroupAndSubgroups "cpw.mods"
         }
     }
+    maven {
+        url "https://thedarkcolour.github.io/KotlinForForge/"
+        content {
+            includeGroupAndSubgroups "thedarkcolour"
+        }
+    }
 }
 
 dependencies {
@@ -43,10 +49,10 @@ dependencies {
     modCompileOnly "dev.emi:emi-neoforge:${rootProject.emi_version}:api"
 
     modRuntimeOnly "dev.emi:emi-neoforge:${rootProject.emi_version}"
-    modRuntimeOnly "maven.modrinth:fzzy-config:${rootProject.fzzy_config_version}+neoforge"
-    //modRuntimeOnly "maven.modrinth:symbols-n-stuff:${rootProject.sns_version}"
+    modRuntimeOnly "me.fzzyhmstrs:fzzy_config:${rootProject.fzzy_config_version}+neoforge"
+    modRuntimeOnly "maven.modrinth:symbols-n-stuff:${rootProject.sns_version}+neoforge"
 
-    modRuntimeOnly "maven.modrinth:kotlin-for-forge:${rootProject.kff_version}"
+    modRuntimeOnly "thedarkcolour:kotlinforforge:${rootProject.kff_version}"
 
     common(project(path: ":xplat", configuration: "namedElements")) { transitive false }
     shadowCommon(project(path: ":xplat", configuration: "transformProductionNeoForge")) { transitive = false }

--- a/neoforge/src/main/resources/META-INF/accesstransformer.cfg
+++ b/neoforge/src/main/resources/META-INF/accesstransformer.cfg
@@ -16,7 +16,7 @@ public net.minecraft.advancements.critereon.PlayerPredicate$AdvancementDonePredi
 public net.minecraft.advancements.critereon.PlayerPredicate$StatMatcher
 
 # SetAttributeLootFunction stuff
-public net.minecraft.world.level.storage.loot.functions.SetAttributesFunction attributes
+public net.minecraft.world.level.storage.loot.functions.SetAttributesFunction modifiers
 public net.minecraft.world.level.storage.loot.functions.SetAttributesFunction$Modifier
 
 # SetStewEffectLootFunction stuff

--- a/xplat/build.gradle
+++ b/xplat/build.gradle
@@ -9,7 +9,7 @@ loom {
 dependencies {
     modImplementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
 
-    modCompileOnly "dev.emi:emi-xplat-intermediary:${project.emi_version}:api"
-    modCompileOnly "maven.modrinth:fzzy-config:${fzzy_config_version}"
-    modCompileOnly "maven.modrinth:symbols-n-stuff:${sns_version}"
+    modCompileOnly "dev.emi:emi-xplat-intermediary:${rootProject.emi_version}:api"
+    modCompileOnly "me.fzzyhmstrs:fzzy_config:${rootProject.fzzy_config_version}"
+    modCompileOnly "maven.modrinth:symbols-n-stuff:${rootProject.sns_version}"
 }

--- a/xplat/src/main/java/fzzyhmstrs/emi_loot/emi/MobLootRecipe.java
+++ b/xplat/src/main/java/fzzyhmstrs/emi_loot/emi/MobLootRecipe.java
@@ -97,7 +97,7 @@ public class MobLootRecipe implements EmiRecipe {
                 try {
                     addWidgetBuilders(builtPool, false);
                 } catch (Throwable e) {
-                    EmiLoot.LOGGER.error("Error encountered while preparing layout for mob recipe {}, display may be incomplete.", loot.id);
+                    EMILoot.LOGGER.error("Error encountered while preparing layout for mob recipe {}, display may be incomplete.", loot.id);
                     e.printStackTrace();
                 }
             }


### PR DESCRIPTION
The field name of an entry in the `accesstransformer.cfg` for EMI Loot on NeoForge was incorrect (it used the Yarn name instead of the Mojmap name). This could cause datapack parsing to fail during world load, as a private field was being accessed without being made public.