### PR TITLE
Restore missing time check; Make biomes, structures, dimensions translatable; 

### DIFF
--- a/xplat/src/main/java/fzzyhmstrs/emi_loot/parser/LocationPredicateParser.java
+++ b/xplat/src/main/java/fzzyhmstrs/emi_loot/parser/LocationPredicateParser.java
@@ -9,7 +9,9 @@ import net.minecraft.predicate.FluidPredicate;
 import net.minecraft.predicate.LightPredicate;
 import net.minecraft.predicate.NumberRange;
 import net.minecraft.predicate.entity.LocationPredicate;
+import net.minecraft.registry.Registries;
 import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
 import net.minecraft.text.Text;
 import net.minecraft.util.Util;
 import net.minecraft.world.World;
@@ -36,17 +38,17 @@ public class LocationPredicateParser {
 
         RegistryKey<World> dim = ((LocationPredicateAccessor)predicate).getDimension();
         if (dim != null) {
-            return LText.translatable("emi_loot.location_predicate.dim", dim.getValue().toString());
+            return LText.translatable("emi_loot.location_predicate.dim", LText.translatable(dim.getValue().toTranslationKey(RegistryKeys.DIMENSION.getValue().getPath())));
         }
 
         RegistryKey<Biome> biome = ((LocationPredicateAccessor)predicate).getBiome();
         if (biome != null) {
-            return LText.translatable("emi_loot.location_predicate.biome", biome.getValue().toString());
+            return LText.translatable("emi_loot.location_predicate.biome", LText.translatable(biome.getValue().toTranslationKey("biome")));
         }
 
         RegistryKey<Structure> feature = ((LocationPredicateAccessor)predicate).getFeature();
         if (feature != null) {
-            return LText.translatable("emi_loot.location_predicate.structure", feature.getValue().toString());
+            return LText.translatable("emi_loot.location_predicate.structure", LText.translatable(feature.getValue().toTranslationKey(RegistryKeys.STRUCTURE.getValue().getPath())));
         }
 
         Boolean smokey = ((LocationPredicateAccessor)predicate).getSmokey();

--- a/xplat/src/main/java/fzzyhmstrs/emi_loot/parser/LocationPredicateParser.java
+++ b/xplat/src/main/java/fzzyhmstrs/emi_loot/parser/LocationPredicateParser.java
@@ -48,7 +48,7 @@ public class LocationPredicateParser {
 
         RegistryKey<Structure> feature = ((LocationPredicateAccessor)predicate).getFeature();
         if (feature != null) {
-            return LText.translatable("emi_loot.location_predicate.structure", LText.translatable(feature.getValue().toTranslationKey(RegistryKeys.STRUCTURE.getValue().getPath())));
+            return LText.translatable("emi_loot.location_predicate.structure", LText.translatable(feature.getValue().toTranslationKey("structure")));
         }
 
         Boolean smokey = ((LocationPredicateAccessor)predicate).getSmokey();

--- a/xplat/src/main/java/fzzyhmstrs/emi_loot/util/TextKey.java
+++ b/xplat/src/main/java/fzzyhmstrs/emi_loot/util/TextKey.java
@@ -124,6 +124,7 @@ public record TextKey(int index, List<Text> args) {
         mapBuilder(53, "emi_loot.condition.raining_false", (key)-> getBasicText(53), Identifier.of(EMILoot.MOD_ID, "textures/gui/sunny.png"));
         mapBuilder(54, "emi_loot.condition.thundering_true", (key)-> getBasicText(54), Identifier.of(EMILoot.MOD_ID, "textures/gui/thundering.png"));
         mapBuilder(55, "emi_loot.condition.thundering_false", (key)-> getBasicText(55), Identifier.of(EMILoot.MOD_ID, "textures/gui/not_thundering.png"));
+        mapBuilder(56, "emi_loot.condition.time_check_period", (key)-> getTwoArgText(56, key), Identifier.of(EMILoot.MOD_ID, "textures/gui/time.png"));
 
 
         //tool tag textkeys


### PR DESCRIPTION

This PR:
1) Restores missing time_check_period TextKey
2) increased screen clarity by making biomes, structures, dimensions translatable since these lines already translated in minecraft/mods

before
<img width="421" height="65" alt="Screenshot 2026-01-22 155052" src="https://github.com/user-attachments/assets/999763d1-30e9-4eb5-a2c0-69e9c470ffc9" />

after
<img width="483" height="66" alt="Screenshot 2026-01-22 160113" src="https://github.com/user-attachments/assets/bbc9343b-cb45-49a1-a2f9-c12d670ba9f9" />

Honestly, I would love to drop that affix, let me know if you do too

Something like Structure Compass mod follows the same rule https://github.com/Samarium150/StructuresCompass/blob/main/src/main/java/io/github/samarium150/minecraft/mod/structures_compass/util/StructureUtils.java#L116